### PR TITLE
Avoid streaming in postgres

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Connection.hs
+++ b/beam-postgres/Database/Beam/Postgres/Connection.hs
@@ -201,7 +201,8 @@ withPgDebug dbg conn (Pg action) =
                    finishUp (PgStreamContinue next') = next' Nothing >>= finishUp
 
                    columnCount = fromIntegral $ valuesNeeded (Proxy @Postgres) (Proxy @x)
-               in Pg.foldWith_ (Pg.RP (put columnCount >> ask)) conn (Pg.Query query) (PgStreamContinue nextStream) runConsumer >>= finishUp
+               in do resp <- Pg.queryWith_ (Pg.RP (put columnCount >> ask)) conn (Pg.Query query)
+                     foldM runConsumer (PgStreamContinue nextStream) resp >>= finishUp
       step (PgRunReturning (PgCommandSyntax PgCommandTypeDataUpdateReturning syntax) mkProcess next) =
         do query <- pgRenderSyntax conn syntax
            dbg (T.unpack (decodeUtf8 query))


### PR DESCRIPTION
Problem: currently postgres uses cursors for all returning operations,
but this requires transactions and may be less efficient in some cases.

Solution: replace `foldWith_` (streaming method) call with `queryWith_`
call, now plain `select`s should be used for querying.

TODO: do we want to make this configurable?