### PR TITLE
Support GHC 8.10

### DIFF
--- a/beam-core/beam-core.cabal
+++ b/beam-core/beam-core.cabal
@@ -84,6 +84,8 @@ library
     ghc-options: -Wcompat
   if flag(werror)
     ghc-options:       -Werror
+  if impl(ghc >= 8.10)
+    default-extensions: TypeFamilyDependencies
 
 flag werror
   description: Enable -Werror during development


### PR DESCRIPTION
Changes: Adds support for GHC-8.10 by including `TypeFamilyDependencies` in `beam-core`
