### PR TITLE
Resolved Issue with Executed time for DB Query

### DIFF
--- a/beam-core/beam-core.cabal
+++ b/beam-core/beam-core.cabal
@@ -84,6 +84,8 @@ library
     ghc-options: -Wcompat
   if flag(werror)
     ghc-options:       -Werror
+  if impl(ghc >= 8.10)
+    default-extensions: TypeFamilyDependencies
 
 flag werror
   description: Enable -Werror during development

--- a/beam-postgres/Database/Beam/Postgres/Connection.hs
+++ b/beam-postgres/Database/Beam/Postgres/Connection.hs
@@ -211,7 +211,7 @@ withPgDebug dbg conn (Pg action) =
                       columnCount = fromIntegral $ valuesNeeded (Proxy @Postgres) (Proxy @x)
                   resp <- Pg.queryWith_ (Pg.RP (put columnCount >> ask)) conn (Pg.Query query)
                   foldM runConsumer (PgStreamContinue nextStream) resp >>= finishUp
-           when (extime /= Nothing) $ dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show ((nsec $ fromJust extime) `div` 1000000)) <> "milli seconds ")
+           when (extime /= Nothing) $ dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show ((nsec $ fromJust extime) `div` 1000000)) <> " ms ")
            when (extime == Nothing) $ dbg (decodeUtf8 query)
            return res
       step (PgRunReturning (PgCommandSyntax PgCommandTypeDataUpdateReturning syntax) mkProcess next) =
@@ -221,7 +221,7 @@ withPgDebug dbg conn (Pg action) =
            res <- Pg.exec conn query
            end <- getTime Monotonic
            let extime = end - start
-           dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show ((nsec extime) `div` 1000000)) <> "milli seconds ")
+           dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show ((nsec extime) `div` 1000000)) <> " ms ")
            sts <- Pg.resultStatus res
            case sts of
              Pg.TuplesOk -> do
@@ -235,7 +235,7 @@ withPgDebug dbg conn (Pg action) =
            _ <- Pg.execute_ conn (Pg.Query query)
            end <- getTime Monotonic
            let extime = end - start
-           dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show ((nsec extime) `div` 1000000)) <> "milli seconds ")
+           dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show ((nsec extime) `div` 1000000)) <> " ms ")
            let Pg process = mkProcess (Pg (liftF (PgFetchNext id)))
            runF process next stepReturningNone
 

--- a/beam-postgres/Database/Beam/Postgres/Connection.hs
+++ b/beam-postgres/Database/Beam/Postgres/Connection.hs
@@ -204,7 +204,10 @@ withPgDebug dbg conn (Pg action) =
                 PgStreamDone (Left err) -> pure (Left err, Nothing)
                 PgStreamContinue nextStream -> do
                   start <- getTime Monotonic
-                  let finishUp (PgStreamDone (Right x)) = (\x y -> (x, Just $ y - start )) <$> next x <*> getTime Monotonic
+                  let finishUp (PgStreamDone (Right x)) = do
+                            output <- next x
+                            end <- getTime Monotonic
+                            pure (output, Just $ end - start)
                       finishUp (PgStreamDone (Left err)) = pure (Left err, Nothing)
                       finishUp (PgStreamContinue next') = next' Nothing >>= finishUp
 

--- a/euler.yaml
+++ b/euler.yaml
@@ -1,0 +1,50 @@
+name: beam
+projects:
+  beam-core:
+    location: beam-core
+    allowed-paths:
+    - beam-core.cabal
+    - Database
+    - LICENSE
+  beam-migrate:
+    location: beam-migrate
+    allowed-paths:
+    - beam-migrate.cabal
+    - Database
+    - tools
+    - LICENSE
+  beam-migrate-cli:
+    location: beam-migrate-cli
+    allowed-paths:
+    - beam-migrate-cli.cabal
+    - Database
+    - BeamMigrate.hs
+    - LICENSE
+  beam-postgres:
+    location: beam-postgres
+    allowed-paths:
+    - beam-postgres.cabal
+    - Database
+    - test
+    - LICENSE
+  beam-sqlite:
+    location: beam-sqlite
+    allowed-paths:
+    - beam-sqlite.cabal
+    - Database
+    - examples
+    - LICENSE
+
+default-project: beam-core
+dependencies:
+  euler-build:
+    branch: master
+    revision: 90f393f7f91e1bb9d7b3c0ece1aa919797d1987b
+overrides:
+  haskell-src-exts:
+    source: hackage
+    version: 1.21.1
+    sha256: 06b37iis7hfnc770gb3jn12dy3yngqcfdraynbvy3n7s0hlv2hcw
+    enable-profiling: true
+  haskell-src-meta:
+    enable-profiling: true


### PR DESCRIPTION
There is an issue in the way how beam calculates the time taken for a query. It is only considering the nanosecond time taken for a query and ignores the seconds taken for the query.

### Issue Description: 

DB Query time is currently calculated in two parts, `seconds` and `nanoseconds` part.
If a DB query takes 2 sec and 4 ns the beam was not considering the nano-seconds part and was not considering seconds values into the calculation part. 

So, the actual DB Query which should be return is `2004 ms` but beam returns `4 ms`

So, I have fixed this issue in this PR.