### PR TITLE
Resolved bug in Calculation of Executed time for DB Query

### DIFF
--- a/beam-postgres/Database/Beam/Postgres/Connection.hs
+++ b/beam-postgres/Database/Beam/Postgres/Connection.hs
@@ -214,7 +214,7 @@ withPgDebug dbg conn (Pg action) =
                       columnCount = fromIntegral $ valuesNeeded (Proxy @Postgres) (Proxy @x)
                   resp <- Pg.queryWith_ (Pg.RP (put columnCount >> ask)) conn (Pg.Query query)
                   foldM runConsumer (PgStreamContinue nextStream) resp >>= finishUp
-           when (extime /= Nothing) $ dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show ((nsec $ fromJust extime) `div` 1000000)) <> " ms ")
+           when (extime /= Nothing) $ dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show (((sec $ fromJust extime) * 1000000000 + (nsec $ fromJust extime)) `div` 1000000)) <> " ms ")
            when (extime == Nothing) $ dbg (decodeUtf8 query)
            return res
       step (PgRunReturning (PgCommandSyntax PgCommandTypeDataUpdateReturning syntax) mkProcess next) =
@@ -224,7 +224,7 @@ withPgDebug dbg conn (Pg action) =
            res <- Pg.exec conn query
            end <- getTime Monotonic
            let extime = end - start
-           dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show ((nsec extime) `div` 1000000)) <> " ms ")
+           dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show (((sec extime) * 1000000000 + (nsec extime)) `div` 1000000)) <> " ms ")
            sts <- Pg.resultStatus res
            case sts of
              Pg.TuplesOk -> do
@@ -238,7 +238,7 @@ withPgDebug dbg conn (Pg action) =
            _ <- Pg.execute_ conn (Pg.Query query)
            end <- getTime Monotonic
            let extime = end - start
-           dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show ((nsec extime) `div` 1000000)) <> " ms ")
+           dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show (((sec extime) * 1000000000 + (nsec extime)) `div` 1000000)) <> " ms ")
            let Pg process = mkProcess (Pg (liftF (PgFetchNext id)))
            runF process next stepReturningNone
 

--- a/beam-postgres/Database/Beam/Postgres/Connection.hs
+++ b/beam-postgres/Database/Beam/Postgres/Connection.hs
@@ -214,7 +214,7 @@ withPgDebug dbg conn (Pg action) =
                       columnCount = fromIntegral $ valuesNeeded (Proxy @Postgres) (Proxy @x)
                   resp <- Pg.queryWith_ (Pg.RP (put columnCount >> ask)) conn (Pg.Query query)
                   foldM runConsumer (PgStreamContinue nextStream) resp >>= finishUp
-           when (extime /= Nothing) $ dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show (((sec $ fromJust extime) * 1000000000 + (nsec $ fromJust extime)) `div` 1000000)) <> " ms ")
+           when (extime /= Nothing) $ dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show (((sec (fromJust extime)) * 1000) + ((nsec (fromJust extime)) `div` 1000000)) <> " ms "))
            when (extime == Nothing) $ dbg (decodeUtf8 query)
            return res
       step (PgRunReturning (PgCommandSyntax PgCommandTypeDataUpdateReturning syntax) mkProcess next) =
@@ -224,7 +224,7 @@ withPgDebug dbg conn (Pg action) =
            res <- Pg.exec conn query
            end <- getTime Monotonic
            let extime = end - start
-           dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show (((sec extime) * 1000000000 + (nsec extime)) `div` 1000000)) <> " ms ")
+           dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show (((sec extime) * 1000) + ((nsec extime) `div` 1000000)) <> " ms "))
            sts <- Pg.resultStatus res
            case sts of
              Pg.TuplesOk -> do
@@ -238,7 +238,7 @@ withPgDebug dbg conn (Pg action) =
            _ <- Pg.execute_ conn (Pg.Query query)
            end <- getTime Monotonic
            let extime = end - start
-           dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show (((sec extime) * 1000000000 + (nsec extime)) `div` 1000000)) <> " ms ")
+           dbg (decodeUtf8 query <> " Executed in: " <> T.pack (show (((sec extime) * 1000) + ((nsec extime) `div` 1000000)) <> " ms "))
            let Pg process = mkProcess (Pg (liftF (PgFetchNext id)))
            runF process next stepReturningNone
 


### PR DESCRIPTION
There is an issue in the way how beam calculates the time taken for a query. It is only considering the nanosecond time taken for a query and ignores the seconds taken for the query.

### Issue Description:
Beam notes a time before running the query and notes a time after running the query and then find the difference between this time (`extime`). 
But it only extracts nanosecond value from the `extime` and does not extracts the seconds taken for the query to run.
If `extime` has value - 2 sec and 4 ms the beam was not considering the seconds part and was only considering nano-seconds values into the calculation part.

So, the actual DB Query which should be return is `2004 ms` but beam returns `4 ms`

So, I have fixed this issue in this PR.